### PR TITLE
Sync mute expiration with database

### DIFF
--- a/dDatabase/GameDatabase/ITables/IAccounts.h
+++ b/dDatabase/GameDatabase/ITables/IAccounts.h
@@ -10,14 +10,15 @@ enum class eGameMasterLevel : uint8_t;
 
 class IAccounts {
 public:
-	struct Info {
-		std::string bcryptPassword;
-		uint32_t id{};
-		uint32_t playKeyId{};
-		bool banned{};
-		bool locked{};
-		eGameMasterLevel maxGmLevel{};
-	};
+        struct Info {
+                std::string bcryptPassword;
+                uint32_t id{};
+                uint32_t playKeyId{};
+               uint64_t muteExpire{};
+                bool banned{};
+                bool locked{};
+                eGameMasterLevel maxGmLevel{};
+        };
 
 	// Get the account info for the given username.
 	virtual std::optional<IAccounts::Info> GetAccountInfo(const std::string_view username) = 0;

--- a/dDatabase/GameDatabase/MySQL/Tables/Accounts.cpp
+++ b/dDatabase/GameDatabase/MySQL/Tables/Accounts.cpp
@@ -3,7 +3,7 @@
 #include "eGameMasterLevel.h"
 
 std::optional<IAccounts::Info> MySQLDatabase::GetAccountInfo(const std::string_view username) {
-	auto result = ExecuteSelect("SELECT id, password, banned, locked, play_key_id, gm_level FROM accounts WHERE name = ? LIMIT 1;", username);
+       auto result = ExecuteSelect("SELECT id, password, banned, locked, play_key_id, gm_level, mute_expire FROM accounts WHERE name = ? LIMIT 1;", username);
 
 	if (!result->next()) {
 		return std::nullopt;
@@ -15,7 +15,8 @@ std::optional<IAccounts::Info> MySQLDatabase::GetAccountInfo(const std::string_v
 	toReturn.bcryptPassword = result->getString("password").c_str();
 	toReturn.banned = result->getBoolean("banned");
 	toReturn.locked = result->getBoolean("locked");
-	toReturn.playKeyId = result->getUInt("play_key_id");
+       toReturn.playKeyId = result->getUInt("play_key_id");
+       toReturn.muteExpire = result->getUInt64("mute_expire");
 
 	return toReturn;
 }

--- a/dDatabase/GameDatabase/SQLite/Tables/Accounts.cpp
+++ b/dDatabase/GameDatabase/SQLite/Tables/Accounts.cpp
@@ -4,7 +4,7 @@
 #include "Database.h"
 
 std::optional<IAccounts::Info> SQLiteDatabase::GetAccountInfo(const std::string_view username) {
-	auto [_, result] = ExecuteSelect("SELECT * FROM accounts WHERE name = ? LIMIT 1", username);
+       auto [_, result] = ExecuteSelect("SELECT * FROM accounts WHERE name = ? LIMIT 1", username);
 
 	if (result.eof()) {
 		return std::nullopt;
@@ -16,7 +16,8 @@ std::optional<IAccounts::Info> SQLiteDatabase::GetAccountInfo(const std::string_
 	toReturn.bcryptPassword = result.getStringField("password");
 	toReturn.banned = result.getIntField("banned");
 	toReturn.locked = result.getIntField("locked");
-	toReturn.playKeyId = result.getIntField("play_key_id");
+       toReturn.playKeyId = result.getIntField("play_key_id");
+       toReturn.muteExpire = static_cast<uint64_t>(result.getInt64Field("mute_expire"));
 
 	return toReturn;
 }

--- a/dGame/User.cpp
+++ b/dGame/User.cpp
@@ -7,6 +7,10 @@
 #include "dZoneManager.h"
 #include "eServerDisconnectIdentifiers.h"
 #include "eGameMasterLevel.h"
+#include "BitStreamUtils.h"
+#include "MessageType/Chat.h"
+#include <chrono>
+#include <ctime>
 
 User::User(const SystemAddress& sysAddr, const std::string& username, const std::string& sessionKey) {
 	m_AccountID = 0;
@@ -24,12 +28,12 @@ User::User(const SystemAddress& sysAddr, const std::string& username, const std:
 
 	m_IsBestFriendMap = std::unordered_map<std::string, bool>();
 
-	auto userInfo = Database::Get()->GetAccountInfo(username);
-	if (userInfo) {
-		m_AccountID = userInfo->id;
-		m_MaxGMLevel = userInfo->maxGmLevel;
-		m_MuteExpire = 0; //res->getUInt64(3);
-	}
+       auto userInfo = Database::Get()->GetAccountInfo(username);
+       if (userInfo) {
+               m_AccountID = userInfo->id;
+               m_MaxGMLevel = userInfo->maxGmLevel;
+               m_MuteExpire = static_cast<time_t>(userInfo->muteExpire);
+       }
 
 	//If we're loading a zone, we'll load the last used (aka current) character:
 	if (Game::server->GetZoneID() != 0) {
@@ -92,7 +96,27 @@ Character* User::GetLastUsedChar() {
 }
 
 bool User::GetIsMuted() const {
-	return m_MuteExpire == 1 || m_MuteExpire > time(NULL);
+       using namespace std::chrono;
+       constexpr auto refreshInterval = seconds{1};
+       const auto now = steady_clock::now();
+       if (now - m_LastMuteCheck >= refreshInterval) {
+               m_LastMuteCheck = now;
+               if (auto info = Database::Get()->GetAccountInfo(m_Username)) {
+                       const auto expire = static_cast<time_t>(info->muteExpire);
+                       if (expire != m_MuteExpire) {
+                               m_MuteExpire = expire;
+
+                               if (Game::chatServer && m_LoggedInCharID != 0) {
+                                       RakNet::BitStream bitStream;
+                                       BitStreamUtils::WriteHeader(bitStream, ServiceType::CHAT, MessageType::Chat::GM_MUTE);
+                                       bitStream.Write(m_LoggedInCharID);
+                                       bitStream.Write(m_MuteExpire);
+                                       Game::chatServer->Send(&bitStream, SYSTEM_PRIORITY, RELIABLE, 0, Game::chatSysAddr, false);
+                               }
+                       }
+               }
+       }
+       return m_MuteExpire == 1 || m_MuteExpire > std::time(nullptr);
 }
 
 time_t User::GetMuteExpire() const {

--- a/dGame/User.h
+++ b/dGame/User.h
@@ -3,6 +3,7 @@
 
 #include <string>
 #include <vector>
+#include <chrono>
 #include "RakNetTypes.h"
 #include "dCommonVars.h"
 
@@ -46,7 +47,7 @@ public:
 	const std::unordered_map<std::string, bool>& GetIsBestFriendMap() { return m_IsBestFriendMap; }
 	void UpdateBestFriendValue(const std::string_view playerName, const bool newValue);
 
-	bool GetIsMuted() const;
+       bool GetIsMuted() const;
 
 	time_t GetMuteExpire() const;
 	void SetMuteExpire(time_t value);
@@ -72,7 +73,8 @@ private:
 	bool m_LastChatMessageApproved = false;
 	int m_AmountOfTimesOutOfSync = 0;
 	const int m_MaxDesyncAllowed = 12;
-	time_t m_MuteExpire;
+       mutable time_t m_MuteExpire;
+       mutable std::chrono::steady_clock::time_point m_LastMuteCheck{};
 };
 
 #endif // USER_H


### PR DESCRIPTION
## Summary
- load and persist account mute expiry from database
- periodically refresh mute status during gameplay and notify chat

## Testing
- `cmake -S . -B build` *(pass)*
- `cmake --build build -j 4` *(fail: missing bcrypt/BCrypt.hpp)*

------
https://chatgpt.com/codex/tasks/task_e_68be4003ed488327ba747bcb688de4cb