### PR TITLE
Add configurable donation return inventory

### DIFF
--- a/dGame/dComponents/DonationVendorComponent.cpp
+++ b/dGame/dComponents/DonationVendorComponent.cpp
@@ -1,3 +1,5 @@
+#include <charconv>
+
 #include "DonationVendorComponent.h"
 #include "Database.h"
 #include "GeneralUtils.h"
@@ -16,9 +18,16 @@ DonationVendorComponent::DonationVendorComponent(Entity* parent, const int32_t c
         const auto& donationInventoryType = m_Parent->GetVar<std::u16string>(u"donationInventoryType");
         if (!donationInventoryType.empty()) {
                 const auto inventoryTypeName = GeneralUtils::UTF16ToWTF8(donationInventoryType);
-                const auto inventoryType = magic_enum::enum_cast<eInventoryType>(inventoryTypeName);
-                if (inventoryType.has_value()) {
+                // Accept either exact-case enum names or case-insensitive matches to be forgiving
+                if (const auto inventoryType = magic_enum::enum_cast<eInventoryType>(inventoryTypeName, magic_enum::case_insensitive)) {
                         m_DonationReturnInventoryType = inventoryType.value();
+                } else {
+                        // Support numeric inventory identifiers for vanity configs that prefer integers
+                        int64_t inventoryTypeId = 0;
+                        const auto [ptr, ec] = std::from_chars(inventoryTypeName.data(), inventoryTypeName.data() + inventoryTypeName.size(), inventoryTypeId);
+                        if (ec == std::errc() && inventoryTypeId >= 0 && inventoryTypeId <= static_cast<int64_t>(eInventoryType::ALL)) {
+                                m_DonationReturnInventoryType = static_cast<eInventoryType>(inventoryTypeId);
+                        }
                 }
         }
 

--- a/dGame/dComponents/DonationVendorComponent.cpp
+++ b/dGame/dComponents/DonationVendorComponent.cpp
@@ -3,6 +3,7 @@
 #include "DonationVendorComponent.h"
 #include "Database.h"
 #include "GeneralUtils.h"
+#include "Logger.h"
 #include "magic_enum.hpp"
 
 DonationVendorComponent::DonationVendorComponent(Entity* parent, const int32_t componentID) : VendorComponent(parent, componentID) {
@@ -21,12 +22,16 @@ DonationVendorComponent::DonationVendorComponent(Entity* parent, const int32_t c
                 // Accept either exact-case enum names or case-insensitive matches to be forgiving
                 if (const auto inventoryType = magic_enum::enum_cast<eInventoryType>(inventoryTypeName, magic_enum::case_insensitive)) {
                         m_DonationReturnInventoryType = inventoryType.value();
+                        LOG("DonationVendorComponent(%llu): using donationInventoryType %s", m_Parent->GetObjectID(), inventoryTypeName.c_str());
                 } else {
                         // Support numeric inventory identifiers for vanity configs that prefer integers
                         int64_t inventoryTypeId = 0;
                         const auto [ptr, ec] = std::from_chars(inventoryTypeName.data(), inventoryTypeName.data() + inventoryTypeName.size(), inventoryTypeId);
                         if (ec == std::errc() && inventoryTypeId >= 0 && inventoryTypeId <= static_cast<int64_t>(eInventoryType::ALL)) {
                                 m_DonationReturnInventoryType = static_cast<eInventoryType>(inventoryTypeId);
+                                LOG("DonationVendorComponent(%llu): using donationInventoryType %s", m_Parent->GetObjectID(), inventoryTypeName.c_str());
+                        } else {
+                                LOG("DonationVendorComponent(%llu): unknown donationInventoryType '%s', defaulting to BRICKS", m_Parent->GetObjectID(), inventoryTypeName.c_str());
                         }
                 }
         }

--- a/dGame/dComponents/DonationVendorComponent.cpp
+++ b/dGame/dComponents/DonationVendorComponent.cpp
@@ -1,5 +1,7 @@
 #include "DonationVendorComponent.h"
 #include "Database.h"
+#include "GeneralUtils.h"
+#include "magic_enum.hpp"
 
 DonationVendorComponent::DonationVendorComponent(Entity* parent, const int32_t componentID) : VendorComponent(parent, componentID) {
 	//LoadConfigData
@@ -7,12 +9,21 @@ DonationVendorComponent::DonationVendorComponent(Entity* parent, const int32_t c
 	m_TotalDonated = 0;
 	m_TotalRemaining = 0;
 
-	// custom attribute to calculate other values
-	m_Goal = m_Parent->GetVar<int32_t>(u"donationGoal");
-	if (m_Goal == 0) m_Goal = INT32_MAX;
+        // custom attribute to calculate other values
+        m_Goal = m_Parent->GetVar<int32_t>(u"donationGoal");
+        if (m_Goal == 0) m_Goal = INT32_MAX;
 
-	// Default to the nexus tower jawbox activity and setup settings
-	m_ActivityId = m_Parent->GetVar<uint32_t>(u"activityID");
+        const auto& donationInventoryType = m_Parent->GetVar<std::u16string>(u"donationInventoryType");
+        if (!donationInventoryType.empty()) {
+                const auto inventoryTypeName = GeneralUtils::UTF16ToWTF8(donationInventoryType);
+                const auto inventoryType = magic_enum::enum_cast<eInventoryType>(inventoryTypeName);
+                if (inventoryType.has_value()) {
+                        m_DonationReturnInventoryType = inventoryType.value();
+                }
+        }
+
+        // Default to the nexus tower jawbox activity and setup settings
+        m_ActivityId = m_Parent->GetVar<uint32_t>(u"activityID");
 	if ((m_ActivityId == 0) || (m_ActivityId == 117)) {
 		m_ActivityId = 117;
 		m_PercentComplete = 1.0;

--- a/dGame/dComponents/DonationVendorComponent.h
+++ b/dGame/dComponents/DonationVendorComponent.h
@@ -3,24 +3,27 @@
 
 #include "VendorComponent.h"
 #include "eReplicaComponentType.h"
+#include "dEnums/eInventoryType.h"
 
 class Entity;
 
 class DonationVendorComponent final : public VendorComponent {
 public:
 	static constexpr eReplicaComponentType ComponentType = eReplicaComponentType::DONATION_VENDOR;
-	DonationVendorComponent(Entity* parent, const int32_t componentID);
-	void Serialize(RakNet::BitStream& outBitStream, bool bIsInitialUpdate) override;
-	uint32_t GetActivityID() {return m_ActivityId;};
-	void SubmitDonation(uint32_t count);
+        DonationVendorComponent(Entity* parent, const int32_t componentID);
+        void Serialize(RakNet::BitStream& outBitStream, bool bIsInitialUpdate) override;
+        uint32_t GetActivityID() {return m_ActivityId;};
+        eInventoryType GetDonationReturnInventoryType() const { return m_DonationReturnInventoryType; }
+        void SubmitDonation(uint32_t count);
 
 private:
-	bool m_DirtyDonationVendor = false;
-	float m_PercentComplete = 0.0;
-	int32_t m_TotalDonated = 0;
-	int32_t m_TotalRemaining = 0;
-	uint32_t m_ActivityId = 0;
-	int32_t m_Goal = 0;
+        bool m_DirtyDonationVendor = false;
+        float m_PercentComplete = 0.0;
+        int32_t m_TotalDonated = 0;
+        int32_t m_TotalRemaining = 0;
+        uint32_t m_ActivityId = 0;
+        int32_t m_Goal = 0;
+        eInventoryType m_DonationReturnInventoryType = eInventoryType::BRICKS;
 };
 
 

--- a/dGame/dGameMessages/GameMessages.cpp
+++ b/dGame/dGameMessages/GameMessages.cpp
@@ -6026,8 +6026,16 @@ void GameMessages::HandleAddDonationItem(RakNet::BitStream& inStream, Entity* en
 	inStream.Read(itemId);
 	if (!itemId) return;
 
-	auto* donationVendorComponent = entity->GetComponent<DonationVendorComponent>();
-	if (!donationVendorComponent) return;
+        auto* donationVendorComponent = entity->GetComponent<DonationVendorComponent>();
+        if (!donationVendorComponent) {
+                if (auto* characterComponent = entity->GetComponent<CharacterComponent>(); characterComponent) {
+                        auto* interactingEntity = Game::entityManager->GetEntity(characterComponent->GetCurrentInteracting());
+                        if (interactingEntity) {
+                                donationVendorComponent = interactingEntity->GetComponent<DonationVendorComponent>();
+                        }
+                }
+        }
+        if (!donationVendorComponent) return;
 	if (donationVendorComponent->GetActivityID() == 0) {
 		LOG("WARNING: Trying to dontate to a vendor with no activity");
 		return;
@@ -6072,6 +6080,13 @@ void GameMessages::HandleRemoveDonationItem(RakNet::BitStream& inStream, Entity*
         auto inventoryType = eInventoryType::BRICKS;
         if (auto* donationVendorComponent = entity->GetComponent<DonationVendorComponent>(); donationVendorComponent) {
                 inventoryType = donationVendorComponent->GetDonationReturnInventoryType();
+        } else if (auto* characterComponent = player->GetComponent<CharacterComponent>(); characterComponent) {
+                auto* donationEntity = Game::entityManager->GetEntity(characterComponent->GetCurrentInteracting());
+                if (donationEntity) {
+                        if (auto* interactingDonationVendor = donationEntity->GetComponent<DonationVendorComponent>(); interactingDonationVendor) {
+                                inventoryType = interactingDonationVendor->GetDonationReturnInventoryType();
+                        }
+                }
         }
         inventoryComponent->MoveItemToInventory(item, inventoryType, count, true, false, true);
 }

--- a/dGame/dGameMessages/GameMessages.cpp
+++ b/dGame/dGameMessages/GameMessages.cpp
@@ -6066,10 +6066,14 @@ void GameMessages::HandleRemoveDonationItem(RakNet::BitStream& inStream, Entity*
 	auto* inventoryComponent = player->GetComponent<InventoryComponent>();
 	if (!inventoryComponent) return;
 
-	Item* item = inventoryComponent->FindItemById(itemId);
-	if (!item) return;
-	if (item->GetCount() < count) return;
-	inventoryComponent->MoveItemToInventory(item, eInventoryType::BRICKS, count, true, false, true);
+        Item* item = inventoryComponent->FindItemById(itemId);
+        if (!item) return;
+        if (item->GetCount() < count) return;
+        auto inventoryType = eInventoryType::BRICKS;
+        if (auto* donationVendorComponent = entity->GetComponent<DonationVendorComponent>(); donationVendorComponent) {
+                inventoryType = donationVendorComponent->GetDonationReturnInventoryType();
+        }
+        inventoryComponent->MoveItemToInventory(item, inventoryType, count, true, false, true);
 }
 
 void GameMessages::HandleConfirmDonationOnPlayer(RakNet::BitStream& inStream, Entity* entity) {
@@ -6102,17 +6106,26 @@ void GameMessages::HandleConfirmDonationOnPlayer(RakNet::BitStream& inStream, En
 }
 
 void GameMessages::HandleCancelDonationOnPlayer(RakNet::BitStream& inStream, Entity* entity) {
-	auto* inventoryComponent = entity->GetComponent<InventoryComponent>();
-	if (!inventoryComponent) return;
-	auto* inventory = inventoryComponent->GetInventory(eInventoryType::DONATION);
-	if (!inventory) return;
-	auto items = inventory->GetItems();
-	for (auto& [itemID, item] : items) {
-		inventoryComponent->MoveItemToInventory(item, eInventoryType::BRICKS, item->GetCount(), false, false, true);
-	}
-	auto* characterComponent = entity->GetComponent<CharacterComponent>();
-	if (!characterComponent) return;
-	characterComponent->SetCurrentInteracting(LWOOBJID_EMPTY);
+        auto* inventoryComponent = entity->GetComponent<InventoryComponent>();
+        if (!inventoryComponent) return;
+        auto* inventory = inventoryComponent->GetInventory(eInventoryType::DONATION);
+        if (!inventory) return;
+        auto returnInventoryType = eInventoryType::BRICKS;
+        if (auto* characterComponent = entity->GetComponent<CharacterComponent>(); characterComponent) {
+                auto* donationEntity = Game::entityManager->GetEntity(characterComponent->GetCurrentInteracting());
+                if (donationEntity) {
+                        if (auto* donationVendorComponent = donationEntity->GetComponent<DonationVendorComponent>(); donationVendorComponent) {
+                                returnInventoryType = donationVendorComponent->GetDonationReturnInventoryType();
+                        }
+                }
+        }
+        auto items = inventory->GetItems();
+        for (auto& [itemID, item] : items) {
+                inventoryComponent->MoveItemToInventory(item, returnInventoryType, item->GetCount(), false, false, true);
+        }
+        auto* characterComponent = entity->GetComponent<CharacterComponent>();
+        if (!characterComponent) return;
+        characterComponent->SetCurrentInteracting(LWOOBJID_EMPTY);
 }
 
 void GameMessages::SendSlashCommandFeedbackText(Entity* entity, std::u16string text) {


### PR DESCRIPTION
## Summary
- allow donation vendors to specify the inventory used when returning donations
- default jawbox donation behavior remains bricks while enabling model-based donors
- capture per-entity donation return inventory type from LDF vars

## Testing
- not run

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69559bd8074083279420c55da77d1dc1)